### PR TITLE
Fix production deploy path and sequential builds

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -47,12 +47,12 @@ jobs:
 
       - name: Validate production env
         env:
-          DEPLOY_DIR: /root/hsts
+          DEPLOY_DIR: /home/nullbox/hsts
         run: scripts/ci/check-prod-env.sh
 
       - name: Deploy selected services
         env:
-          DEPLOY_DIR: /root/hsts
+          DEPLOY_DIR: /home/nullbox/hsts
           DEPLOY_BACKEND: ${{ inputs.deploy_backend }}
           DEPLOY_FRONTEND: ${{ inputs.deploy_frontend }}
         run: scripts/ci/deploy-prod.sh

--- a/scripts/ci/check-prod-env.sh
+++ b/scripts/ci/check-prod-env.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEPLOY_DIR="${DEPLOY_DIR:-/root/hsts}"
+DEPLOY_DIR="${DEPLOY_DIR:-/home/nullbox/hsts}"
 ENV_FILE="${ENV_FILE:-$DEPLOY_DIR/.env}"
 
-if [[ ! -f "$ENV_FILE" ]]; then
+run_root() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  else
+    sudo "$@"
+  fi
+}
+
+if ! run_root test -f "$ENV_FILE"; then
   echo "Missing production env file: $ENV_FILE" >&2
   exit 1
 fi
@@ -28,7 +36,7 @@ required_keys=(
 )
 
 for key in "${required_keys[@]}"; do
-  if ! grep -Eq "^${key}=.+" "$ENV_FILE"; then
+  if ! run_root grep -Eq "^${key}=.+" "$ENV_FILE"; then
     echo "Missing required key in $ENV_FILE: $key" >&2
     exit 1
   fi

--- a/scripts/ci/deploy-prod.sh
+++ b/scripts/ci/deploy-prod.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-DEPLOY_DIR="${DEPLOY_DIR:-/root/hsts}"
+DEPLOY_DIR="${DEPLOY_DIR:-/home/nullbox/hsts}"
 COMPOSE_FILE="${COMPOSE_FILE:-docker-compose.prod.yml}"
 SOURCE_DIR="${SOURCE_DIR:-$PWD}"
 DEPLOY_BACKEND="${DEPLOY_BACKEND:-true}"

--- a/scripts/ci/deploy-prod.sh
+++ b/scripts/ci/deploy-prod.sh
@@ -40,19 +40,13 @@ run_root rsync -a --delete \
 
 pushd "$DEPLOY_DIR" >/dev/null
 
-build_targets=()
-up_targets=()
-
 if [[ "$DEPLOY_BACKEND" == "true" ]]; then
-  build_targets+=("backend")
-  up_targets+=("backend")
+  run_root docker compose -f "$COMPOSE_FILE" build backend
 fi
 
 if [[ "$DEPLOY_FRONTEND" == "true" ]]; then
-  build_targets+=("nginx")
+  run_root docker compose -f "$COMPOSE_FILE" build nginx
 fi
-
-run_root docker compose -f "$COMPOSE_FILE" build "${build_targets[@]}"
 
 if [[ "$DEPLOY_BACKEND" == "true" ]]; then
   run_root docker compose -f "$COMPOSE_FILE" up -d backend


### PR DESCRIPTION
This PR updates the production deploy flow after the first deploy workflow run on main exposed runtime issues on the Droplet.\n\nIncluded:\n- move deploy path handling to /home/nullbox/hsts\n- make deploy env validation compatible with runner permissions\n- build backend and frontend images sequentially to avoid build kills on the current Droplet\n\nPurpose:\n- stabilize deploy-prod.yml on the current self-hosted runner and production server\n