### PR TITLE
fix(fe): add missing LeftOutlined import in reset password form

### DIFF
--- a/HSTS.FE/src/features/auth/components/ResetPasswordForm.jsx
+++ b/HSTS.FE/src/features/auth/components/ResetPasswordForm.jsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { Button, Card, Form, Input, Typography } from 'antd';
-import { LockOutlined } from '@ant-design/icons';
+import { LeftOutlined, LockOutlined } from '@ant-design/icons';
 import { Link, Navigate, useLocation } from 'react-router-dom';
 import { useResetPassword, useResendOtp, useVerifyForgotPasswordOtp } from '../hooks/useAuth';
 import OtpVerificationStep from './OtpVerificationStep';


### PR DESCRIPTION
Fixes a runtime ReferenceError on the reset password page by importing the missing Ant Design icon used in the back-link. Validation: npm run build and npm run lint.