### PR TITLE
Hardens migration adoption for existing schemas

### DIFF
--- a/HSTS.BE/HSTS.API/Program.cs
+++ b/HSTS.BE/HSTS.API/Program.cs
@@ -6,13 +6,18 @@ using HSTS.Application.Auth.Interfaces;
 using HSTS.Infrastructure.Persistence;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.AspNetCore.RateLimiting;
+using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 
 namespace HSTS.API
 {
     public class Program
     {
+        private const string BaselineMigrationId = "20260418193423_BaselineFromCurrentCode";
+        private const string TransportSchemaSyncMigrationId = "20260422225513_TransportSchemaSync";
+
         public static void Main(string[] args)
         {
             var builder = WebApplication.CreateBuilder(args);
@@ -113,25 +118,9 @@ namespace HSTS.API
             using (var scope = app.Services.CreateScope())
             {
                 var db = scope.ServiceProvider.GetRequiredService<AppDbContext>();
-                if (db.Database.CanConnect())
-                {
-                    var applied = db.Database.GetAppliedMigrations().ToHashSet();
-                    if (applied.Count == 0)
-                    {
-                        // DB has tables but no migration history — mark all known migrations as applied
-                        var efVersion = typeof(DbContext).Assembly.GetName().Version!.ToString(3);
-                        db.Database.ExecuteSqlRaw("""
-                            CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
-                                `MigrationId` varchar(150) NOT NULL,
-                                `ProductVersion` varchar(32) NOT NULL,
-                                PRIMARY KEY (`MigrationId`)
-                            );
-                            """);
-                        foreach (var migration in db.Database.GetMigrations())
-                            db.Database.ExecuteSqlRaw(
-                                $"INSERT IGNORE INTO `__EFMigrationsHistory` VALUES ('{migration}', '{efVersion}');");
-                    }
-                }
+                var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+
+                EnsureMigrationHistoryAligned(db, logger);
                 db.Database.Migrate();
             }
 
@@ -171,6 +160,146 @@ namespace HSTS.API
             app.MapControllers();
 
             app.Run();
+        }
+
+        private static void EnsureMigrationHistoryAligned(AppDbContext db, ILogger logger)
+        {
+            if (!db.Database.CanConnect())
+            {
+                logger.LogWarning("Skipping migration history alignment because the database connection is unavailable.");
+                return;
+            }
+
+            EnsureMigrationHistoryTable(db);
+
+            var applied = db.Database.GetAppliedMigrations().ToHashSet(StringComparer.OrdinalIgnoreCase);
+            if (applied.Count > 0)
+            {
+                logger.LogInformation("Existing migration history detected: {AppliedMigrations}", string.Join(", ", applied));
+                return;
+            }
+
+            var businessTables = new[] { "Accounts", "TransportModes", "LocalTransportMetrics" };
+            var existingBusinessTables = businessTables.Where(table => TableExists(db, table)).ToArray();
+
+            if (existingBusinessTables.Length == 0)
+            {
+                logger.LogInformation("No business tables detected. Treating database as empty and letting EF apply migrations normally.");
+                return;
+            }
+
+            if (existingBusinessTables.Length != businessTables.Length)
+            {
+                throw new InvalidOperationException(
+                    "Database has partial baseline schema but no migration history. " +
+                    $"Expected tables [{string.Join(", ", businessTables)}], found [{string.Join(", ", existingBusinessTables)}]. " +
+                    "Refusing automatic migration adoption because the schema state is ambiguous.");
+            }
+
+            var transportSchemaState = DetectLocalTransportMetricsSchemaState(db);
+            var efVersion = typeof(DbContext).Assembly.GetName().Version!.ToString(3);
+
+            using var transaction = db.Database.BeginTransaction();
+
+            InsertMigrationHistory(db, BaselineMigrationId, efVersion);
+            logger.LogWarning(
+                "Adopted existing schema as baseline migration {MigrationId} because business tables already exist without migration history.",
+                BaselineMigrationId);
+
+            if (transportSchemaState == LocalTransportMetricsSchemaState.PostTransportSync)
+            {
+                InsertMigrationHistory(db, TransportSchemaSyncMigrationId, efVersion);
+                logger.LogWarning(
+                    "Detected post-sync LocalTransportMetrics schema; adopted migration {MigrationId} as already applied.",
+                    TransportSchemaSyncMigrationId);
+            }
+            else
+            {
+                logger.LogInformation(
+                    "Detected pre-sync LocalTransportMetrics schema; {MigrationId} will remain pending and run through EF migrations.",
+                    TransportSchemaSyncMigrationId);
+            }
+
+            transaction.Commit();
+        }
+
+        private static void EnsureMigrationHistoryTable(AppDbContext db)
+        {
+            db.Database.ExecuteSqlRaw("""
+                CREATE TABLE IF NOT EXISTS `__EFMigrationsHistory` (
+                    `MigrationId` varchar(150) NOT NULL,
+                    `ProductVersion` varchar(32) NOT NULL,
+                    PRIMARY KEY (`MigrationId`)
+                );
+                """);
+        }
+
+        private static void InsertMigrationHistory(AppDbContext db, string migrationId, string productVersion)
+        {
+            db.Database.ExecuteSqlRaw(
+                "INSERT IGNORE INTO `__EFMigrationsHistory` (`MigrationId`, `ProductVersion`) VALUES ({0}, {1});",
+                migrationId,
+                productVersion);
+        }
+
+        private static bool TableExists(AppDbContext db, string tableName)
+            => QueryExists(
+                db,
+                "SELECT 1 FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = {0} LIMIT 1;",
+                tableName);
+
+        private static bool ColumnExists(AppDbContext db, string tableName, string columnName)
+            => QueryExists(
+                db,
+                "SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = {0} AND COLUMN_NAME = {1} LIMIT 1;",
+                tableName,
+                columnName);
+
+        private static bool QueryExists(AppDbContext db, string sql, params object[] parameters)
+            => db.Database.SqlQueryRaw<int>(sql, parameters).Any();
+
+        private static LocalTransportMetricsSchemaState DetectLocalTransportMetricsSchemaState(AppDbContext db)
+        {
+            const string tableName = "LocalTransportMetrics";
+
+            var hasCostPerKm = ColumnExists(db, tableName, "CostPerKm");
+            var hasPricePerKm = ColumnExists(db, tableName, "PricePerKm");
+            var hasBaseDistance = ColumnExists(db, tableName, "BaseDistance");
+            var hasBaseFare = ColumnExists(db, tableName, "BaseFare");
+            var hasCongestionFeePerMinute = ColumnExists(db, tableName, "CongestionFeePerMinute");
+            var hasLongDistancePricePerKm = ColumnExists(db, tableName, "LongDistancePricePerKm");
+            var hasLongDistanceThreshold = ColumnExists(db, tableName, "LongDistanceThreshold");
+
+            var hasAnyPostSyncColumns = hasBaseDistance
+                || hasBaseFare
+                || hasCongestionFeePerMinute
+                || hasLongDistancePricePerKm
+                || hasLongDistanceThreshold;
+
+            var hasAllPostSyncColumns = hasBaseDistance
+                && hasBaseFare
+                && hasCongestionFeePerMinute
+                && hasLongDistancePricePerKm
+                && hasLongDistanceThreshold;
+
+            if (hasCostPerKm && !hasPricePerKm && !hasAnyPostSyncColumns)
+                return LocalTransportMetricsSchemaState.PreTransportSync;
+
+            if (!hasCostPerKm && hasPricePerKm && hasAllPostSyncColumns)
+                return LocalTransportMetricsSchemaState.PostTransportSync;
+
+            throw new InvalidOperationException(
+                "Database contains LocalTransportMetrics but its schema does not match a supported migration fingerprint. " +
+                $"Detected columns: CostPerKm={hasCostPerKm}, PricePerKm={hasPricePerKm}, BaseDistance={hasBaseDistance}, " +
+                $"BaseFare={hasBaseFare}, CongestionFeePerMinute={hasCongestionFeePerMinute}, " +
+                $"LongDistancePricePerKm={hasLongDistancePricePerKm}, LongDistanceThreshold={hasLongDistanceThreshold}. " +
+                "Refusing automatic migration adoption because the schema state is ambiguous.");
+        }
+
+        private enum LocalTransportMetricsSchemaState
+        {
+            PreTransportSync,
+            PostTransportSync,
         }
     }
 }


### PR DESCRIPTION
Improves the application's startup process to robustly handle existing database schemas that lack EF Core migration history.

The new logic ensures that:
- When connecting to an existing database without recorded EF migrations, the system intelligently detects the schema state.
- If core business tables exist, it automatically marks the relevant baseline migration as applied.
- Further, it detects the specific schema state of the `LocalTransportMetrics` table (pre- or post-transport sync) and marks the corresponding `TransportSchemaSync` migration as applied if the schema matches the post-sync state.
- This prevents EF Core from attempting to re-apply migrations to an already existing structure, avoiding common startup errors.
- Includes checks to prevent automatic adoption if the detected schema state is ambiguous or partial, ensuring data integrity.