### PR TITLE
feat(fe): add map search and link paste to create-trip starting point

### DIFF
--- a/HSTS.FE/src/features/trip/pages/CreateTripPage.jsx
+++ b/HSTS.FE/src/features/trip/pages/CreateTripPage.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useMemo, useCallback, useEffect, useRef } from 'react';
-import { Form, InputNumber, DatePicker, Select, Button, Card, Radio, Typography, Row, Col, Checkbox, Tag, Spin, message, ConfigProvider, Steps, Alert } from 'antd';
+import { Form, Input, InputNumber, DatePicker, Select, Button, Card, Radio, Typography, Row, Col, Checkbox, Tag, Spin, message, ConfigProvider, Steps, Alert, AutoComplete, Space } from 'antd';
+import { SearchOutlined, EnvironmentOutlined } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { MapContainer, Marker, TileLayer, useMap, useMapEvents } from 'react-leaflet';
@@ -9,6 +10,8 @@ import { useTripFormData, parseTripPrefillParams } from '../hooks/useTripFormDat
 import { useTripPlanner } from '../hooks/useTripPlanner';
 import { CURRENCY_OPTIONS } from '../constants/currency';
 import GoogleMapPicker from '@/components/GoogleMapPicker';
+import MapLinkInput from '@/components/MapLinkInput';
+import useNominatimSearch from '@/hooks/useNominatimSearch';
 import { PATHS } from '@/routes/paths';
 import styles from '../styles/CreateTripPage.module.css';
 
@@ -88,6 +91,7 @@ const CreateTripPage = () => {
   const [currentStep, setCurrentStep] = useState(0);
   const [mapOpen, setMapOpen] = useState(false);
   const [userLocation, setUserLocation] = useState(null);
+  const { searchValue, searchOptions, searching, handleSearch, handleSelect } = useNominatimSearch();
   const [destinations, setDestinations] = useState([]);
   const [selectedTagIds, setSelectedTagIds] = useState([]);
   const [activeParentTagId, setActiveParentTagId] = useState(null);
@@ -334,6 +338,14 @@ const CreateTripPage = () => {
     setMapOpen(false);
   }, [form]);
 
+  const handleMapLinkParsed = useCallback(({ lat, lng }) => {
+    if (lat != null && lng != null) {
+      setUserLocation({ latitude: lat, longitude: lng });
+      form.setFieldsValue({ latitude: lat, longitude: lng });
+      message.success('Location from map link applied!');
+    }
+  }, [form]);
+
   const handleAddDestination = useCallback((provinceId) => {
     if (!provinceId) return;
     if (destinations.find((d) => d.provinceId === provinceId)) {
@@ -552,6 +564,31 @@ const CreateTripPage = () => {
 
             <div className={currentStep === 0 ? styles.stepActive : styles.stepHidden}>
               <Card className={styles.sectionCard} title={<span className={styles.sectionTitle}>Where are you starting from?</span>}>
+                <div className={styles.mapSearchWrap} style={{ marginBottom: 12 }}>
+                  <Space.Compact style={{ width: '100%' }}>
+                    <AutoComplete
+                      style={{ flex: 1 }}
+                      options={searchOptions}
+                      value={searchValue}
+                      onSearch={handleSearch}
+                      onSelect={(value, option) => {
+                        const result = handleSelect(value, option);
+                        if (result) {
+                          setUserLocation({ latitude: result.lat, longitude: result.lon });
+                          form.setFieldsValue({ latitude: result.lat, longitude: result.lon });
+                          message.success('Location found!');
+                        }
+                      }}
+                      placeholder="Search for a place (e.g., 'Ben Thanh Market')"
+                    >
+                      <Input suffix={<SearchOutlined />} style={{ borderRadius: '8px 0 0 8px' }} />
+                    </AutoComplete>
+                    <Button onClick={handleGetCurrentLocation} icon={<EnvironmentOutlined />} style={{ borderRadius: '0 8px 8px 0' }}>
+                      My Location
+                    </Button>
+                  </Space.Compact>
+                </div>
+                <MapLinkInput onParsed={handleMapLinkParsed} />
                 <div className={styles.mapInlineWrapper}>
                   <MapContainer center={mapCenter} zoom={12} style={{ width: '100%', height: 280, borderRadius: 16 }}>
                     <TileLayer url="http://{s}.google.com/vt/lyrs=m&x={x}&y={y}&z={z}" subdomains={['mt0', 'mt1', 'mt2', 'mt3']} attribution='© <a href="https://www.google.com/maps">Google Maps</a>' maxZoom={20} />
@@ -560,9 +597,6 @@ const CreateTripPage = () => {
                     <InlineMapCenterSync center={mapCenter} />
                   </MapContainer>
                 </div>
-                <Button type="dashed" block onClick={handleGetCurrentLocation} style={{ marginTop: 16, borderColor: '#4ECDC4', color: '#1A535C', backgroundColor: 'rgba(78, 205, 196, 0.1)' }}>
-                  Use My Current Location
-                </Button>
                 <GoogleMapPicker open={mapOpen} onClose={() => setMapOpen(false)} onConfirm={handleMapConfirm} initialLat={userLocation?.latitude} initialLng={userLocation?.longitude} />
               </Card>
 

--- a/HSTS.FE/src/features/trip/styles/CreateTripPage.module.css
+++ b/HSTS.FE/src/features/trip/styles/CreateTripPage.module.css
@@ -1,5 +1,19 @@
 @import url('https://fonts.googleapis.com/css2?family=Caveat:wght@700&family=Plus+Jakarta+Sans:wght@400;500;600;700&display=swap');
 
+/* Hide AutoComplete mirror text node that leaks outside the input.
+   AutoComplete extends Select and renders a "mirror" text in .ant-select-content
+   for width measurement. With Space.Compact, this text becomes visible. */
+.mapSearchWrap :global(.ant-select-content) {
+  font-size: 0;
+  line-height: 0;
+}
+
+.mapSearchWrap :global(.ant-select-content) :global(.ant-input-affix-wrapper),
+.mapSearchWrap :global(.ant-select-content) input {
+  font-size: 14px;
+  line-height: normal;
+}
+
 .createTripPage {
   min-height: 100vh;
   background-color: #F7F9F9;

--- a/HSTS.FE/src/hooks/useNominatimSearch.js
+++ b/HSTS.FE/src/hooks/useNominatimSearch.js
@@ -1,0 +1,68 @@
+import { useState, useRef, useCallback } from 'react';
+
+const NOMINATIM_URL = 'https://nominatim.openstreetmap.org/search';
+const DEBOUNCE_MS = 400;
+const MIN_QUERY_LENGTH = 3;
+const RESULT_LIMIT = 5;
+
+const useNominatimSearch = () => {
+  const [searchValue, setSearchValue] = useState('');
+  const [searchOptions, setSearchOptions] = useState([]);
+  const [searching, setSearching] = useState(false);
+  const timerRef = useRef(null);
+
+  const handleSearch = useCallback((value) => {
+    setSearchValue(value);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    if (!value || value.length < MIN_QUERY_LENGTH) {
+      setSearchOptions([]);
+      return;
+    }
+    timerRef.current = setTimeout(async () => {
+      setSearching(true);
+      try {
+        const res = await fetch(
+          `${NOMINATIM_URL}?format=json&q=${encodeURIComponent(value)}&limit=${RESULT_LIMIT}&addressdetails=1`,
+          { headers: { 'Accept-Language': 'en' } },
+        );
+        const data = await res.json();
+        setSearchOptions(
+          data.map((item) => ({
+            value: `${item.lat},${item.lon}`,
+            label: item.display_name,
+            lat: parseFloat(item.lat),
+            lon: parseFloat(item.lon),
+          })),
+        );
+      } catch {
+        setSearchOptions([]);
+      } finally {
+        setSearching(false);
+      }
+    }, DEBOUNCE_MS);
+  }, []);
+
+  const handleSelect = useCallback((value, option) => {
+    const lat = Number(option.lat);
+    const lon = Number(option.lon);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) return null;
+    setSearchValue(option.label);
+    return { lat, lon, label: option.label };
+  }, []);
+
+  const resetSearch = useCallback(() => {
+    setSearchValue('');
+    setSearchOptions([]);
+  }, []);
+
+  return {
+    searchValue,
+    searchOptions,
+    searching,
+    handleSearch,
+    handleSelect,
+    resetSearch,
+  };
+};
+
+export default useNominatimSearch;


### PR DESCRIPTION
Extract Nominatim search into reusable useNominatimSearch hook and add
inline search bar + MapLinkInput to CreateTripPage origin picker,
matching the UX of GoogleMapPicker used elsewhere.
